### PR TITLE
Quickfix for a setting mistake

### DIFF
--- a/includes/views/wp-listings-settings.php
+++ b/includes/views/wp-listings-settings.php
@@ -92,7 +92,7 @@ if ( isset( $_GET['settings-updated'] ) ) {
 					<?php
 					}
 
-					if ( ! isset( $options['wplpro_api_key'] ) || get_option('idx_broker_apikey') !== false ) {
+					if ( ! isset( $options['wplpro_api_key'] ) && get_option('idx_broker_apikey') !== false ) {
 						$options['wplpro_api_key'] = get_option('idx_broker_apikey');
 						update_option( 'wplpro_plugin_settings', $options );
 					}


### PR DESCRIPTION
Added a quickfix so that the API key would not keep getting reset by the IDX Broker API key value (use ours if it exists, not theirs).

Fixed so fast there's not even an issue for it yet.